### PR TITLE
Pedantic readme fix: Messages are region-limited (not chunk-limited)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,15 +53,13 @@ The API key can be found in the plugin settings under the "Account" section.
 
 https://github.com/user-attachments/assets/08dec20e-98b0-4d3e-b086-9f694d926162
 
-
-
 ## Rate Limits
 
 To keep things fair and prevent spam:
 
 | Limit | Amount |
 |-------|--------|
-| Messages per region (chunk) | 1 |
+| Messages per 64x64 region | 1 |
 | Messages per world | 5 |
 | Max characters per message | 100 |
 


### PR DESCRIPTION
This small improvement clarifies that messages are region-limited (64x64), not chunk-limited (8x8).

I had my chat filter set to "clan only" and couldn't see any of the plugin errors, which would have explained why my messages kept getting eaten 😅